### PR TITLE
Merge ralph-dev env parity into master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,16 @@ permissions:
 
 jobs:
   build-test:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.platform.name }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform.runner }}
 
     strategy:
       fail-fast: false
       matrix:
-        include:
+        python-version:
+          - '3.13'
+          - '3.14'
+        platform:
           - name: Linux x64
             runner: ubuntu-24.04
             artifact: linux-x64
@@ -43,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -60,7 +63,7 @@ jobs:
       - name: Upload distributions
         uses: actions/upload-artifact@v7
         with:
-          name: gym-tetris-${{ matrix.artifact }}-dist
+          name: gym-tetris-${{ matrix.platform.artifact }}-py${{ matrix.python-version }}-dist
           path: dist/*
           if-no-files-found: error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to `gym-tetris` are documented in this file.
+
+This changelog was reconstructed from local git tags, version metadata, and
+repository history.
+
+## 4.0.0 (upcoming)
+
+Current package metadata in `pyproject.toml` is set to `4.0.0`, but no local
+`4.0.0` tag exists yet.
+
+### Highlights
+
+- Migrated the package from the legacy Gym API to Gymnasium, including updated
+  environment reset and step behavior, CLI support, and refreshed tests.
+- Modernized packaging by replacing `setup.py` with `pyproject.toml`.
+- Aligned CI and supported Python versions with `nes-py`.
+- Added GitHub Actions workflows for CI and trusted PyPI publishing.
+- Replaced the old makefile-oriented maintenance flow with `main.sh`.
+- Clarified wrapper bootstrap metadata policy in `requirements.txt`.
+
+### Release notes
+
+- Expect this release to be the first Gymnasium-native major version.
+- Downstream users should plan for API updates consistent with Gymnasium's
+  `reset()` and `step()` signatures.
+- Release automation now assumes GitHub Actions plus PyPI trusted publishing.
+
+## 3.0.4 - 2022-09-09
+
+- Removed an extra reset call during deterministic environment setup.
+
+## 3.0.3 - 2022-09-09
+
+- Added CLI random seed support.
+- Fixed random number seeding in the Tetris environment for more reliable
+  reproducibility.
+
+## 3.0.2 - 2019-06-02
+
+- Avoided replaying the start-screen flow on every reset.
+- Improved game completion handling for win conditions.
+
+## 3.0.1 - 2019-06-02
+
+- Added `board_height` to the environment `info` dictionary.
+
+## 3.0.0 - 2019-06-02
+
+- Introduced separate A-type and B-type Tetris environments.
+- Updated registration and documentation for the split game modes.
+
+## 2.3.0 - 2019-06-02
+
+- Added reward variants that combine line-based rewards with board-height
+  penalties.
+- Added board-height tracking used by the new reward modes.
+
+## 2.2.3 - 2019-06-02
+
+- Updated CLI behavior and package metadata around the `2.2.x` release line.
+
+## 2.2.2 - 2019-05-29
+
+- Fixed the line-count reward stream so it triggers only once per clear.
+- Fixed command-line environment selection.
+
+## 2.2.1 - 2019-05-24
+
+- Refreshed project metadata and maintenance scripts.
+
+## 2.2.0 - 2019-05-24
+
+- Added a new alternate reward stream.
+- Added a CLI environment flag.
+- Documented the new environment and reward behavior.
+
+## 2.1.0 - 2019-05-24
+
+- Updated action definitions and package configuration ahead of the `2.2.x`
+  reward-stream work.
+
+## 2.0.2 - 2019-05-23
+
+- Fixed a post-`2.0.1` packaging/runtime error.
+
+## 2.0.1 - 2019-05-23
+
+- Shipped a quick follow-up release after the `2.0.0` backend transition.
+
+## 2.0.0 - 2019-05-23
+
+- Merged the `nes-backend` work that re-based the project on the newer
+  emulator/backend stack.
+
+## 0.1.0 - 1.2.10
+
+- Early releases established the initial NES Tetris environment, human/random
+  play support, packaging refinements, wheel/source distribution fixes, scoring
+  updates, frame-limit and server-rendering fixes, and CLI/application
+  refactors.
+- The `1.2.x` line also introduced the height-related work that later informed
+  the `board_height` info field and reward variants.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   width="320px" />
 </p>
 
-An [OpenAI Gym](https://github.com/openai/gym) environment for Tetris on The
+A [Gymnasium](https://gymnasium.farama.org/) environment for Tetris on The
 Nintendo Entertainment System (NES) based on the
 [nes-py](https://github.com/Kautenja/nes-py) emulator.
 
@@ -43,7 +43,7 @@ pip install gym-tetris
 ### Python
 
 You must import `gym_tetris` before trying to make an environment.
-This is because gym environments are registered at runtime. By default,
+This is because Gymnasium environments are registered at runtime. By default,
 `gym_tetris` environments use the full NES action space of 256
 discrete actions. To constrain this, `gym_tetris.actions` provides
 an action list called `MOVEMENT` (20 discrete actions) for the
@@ -52,24 +52,28 @@ an action list called `MOVEMENT` (20 discrete actions) for the
 see [gym_tetris/actions.py](gym_tetris/actions.py).
 
 ```python
+import gymnasium as gym
 from nes_py.wrappers import JoypadSpace
 import gym_tetris
 from gym_tetris.actions import MOVEMENT
 
-env = gym_tetris.make('TetrisA-v0')
+env = gym.make('TetrisA-v0', render_mode='rgb_array')
 env = JoypadSpace(env, MOVEMENT)
 
 done = True
 for step in range(5000):
     if done:
-        state = env.reset()
-    state, reward, done, info = env.step(env.action_space.sample())
+        state, info = env.reset(seed=123)
+    state, reward, terminated, truncated, info = env.step(
+        env.action_space.sample()
+    )
+    done = terminated or truncated
     env.render()
 
 env.close()
 ```
 
-**NOTE:** `gym_tetris.make` is just an alias to `gym.make` for
+**NOTE:** `gym_tetris.make` is just an alias to `gymnasium.make` for
 convenience.
 
 **NOTE:** remove calls to `render` in training code for a nontrivial
@@ -81,7 +85,8 @@ speedup.
 environments using either the keyboard, or uniform random movement.
 
 ```shell
-gym_tetris -e <environment ID> -m <`human` or `random`>
+gym_tetris -e <environment ID> -m <human or random> --seed 123
+gym_tetris -e TetrisA-v0 -m random --no-render --steps 100
 ```
 
 ## Environments
@@ -135,7 +140,7 @@ Please cite `gym-tetris` if you use it in your research.
 @misc{gym-tetris,
   author = {Christian Kauten},
   howpublished = {GitHub},
-  title = {{Tetris (NES)} for {OpenAI Gym}},
+  title = {{Tetris (NES)} for {Gymnasium}},
   URL = {https://github.com/Kautenja/gym-tetris},
   year = {2019},
 }

--- a/gym_tetris/_app/cli.py
+++ b/gym_tetris/_app/cli.py
@@ -1,9 +1,9 @@
-"""Tetris for OpenAI Gym."""
+"""Tetris for Gymnasium."""
 import argparse
-import gym
+import gymnasium as gym
 from nes_py.wrappers import JoypadSpace
-from nes_py.app.play_human import play_human
-from nes_py.app.play_random import play_random
+from nes_py.play import play_human
+from nes_py.play import play_random
 from ..actions import MOVEMENT, SIMPLE_MOVEMENT
 
 
@@ -12,6 +12,22 @@ _ACTION_SPACES = {
     'simple': SIMPLE_MOVEMENT,
     'standard': MOVEMENT,
 }
+
+
+class FirstResetSeed(gym.Wrapper):
+    """Inject a CLI seed into the first Gymnasium reset call."""
+
+    def __init__(self, env, seed):
+        """Initialize the wrapper with a one-shot seed."""
+        super().__init__(env)
+        self._first_reset_seed = seed
+
+    def reset(self, *, seed=None, options=None):
+        """Reset the environment, applying the CLI seed once."""
+        if self._first_reset_seed is not None and seed is None:
+            seed = self._first_reset_seed
+            self._first_reset_seed = None
+        return self.env.reset(seed=seed, options=options)
 
 
 def _get_args():
@@ -48,7 +64,15 @@ def _get_args():
         default=500,
         help='The number of random steps to take.',
     )
-    return parser.parse_args()
+    parser.add_argument('--render',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help='render random-mode frames to a graphical window',
+    )
+    args = parser.parse_args()
+    if args.mode == 'human' and not args.render:
+        parser.error('human mode requires graphical rendering')
+    return args
 
 
 def main():
@@ -56,9 +80,10 @@ def main():
     # parse arguments from the command line (argparse validates arguments)
     args = _get_args()
     # build the environment with the given ID
-    env = gym.make(args.env)
+    render_mode = 'human' if args.mode == 'random' and args.render else None
+    env = gym.make(args.env, render_mode=render_mode)
     if args.seed is not None:
-        env.seed(args.seed)
+        env = FirstResetSeed(env, args.seed)
     # wrap the environment with an action space if specified
     if args.actionspace != 'nes':
         # unwrap the actions list by key
@@ -69,7 +94,7 @@ def main():
     if args.mode == 'human':
         play_human(env)
     else:
-        play_random(env, args.steps)
+        play_random(env, args.steps, render=args.render)
 
 
 # explicitly define the outward facing API of this module

--- a/gym_tetris/_registration.py
+++ b/gym_tetris/_registration.py
@@ -1,5 +1,5 @@
-"""A script for registering environments with gym."""
-import gym
+"""A script for registering environments with Gymnasium."""
+import gymnasium as gym
 
 
 # register for game mode A and B

--- a/gym_tetris/tests/test_registration.py
+++ b/gym_tetris/tests/test_registration.py
@@ -1,80 +1,142 @@
-"""Test cases for the gym registered environments."""
+"""Test cases for the Gymnasium registered environments."""
+import warnings
 from unittest import TestCase
+
+import gymnasium as gym
+
 from .. import make
 
 
+REGISTERED_ENVIRONMENTS = {
+    'TetrisA-v0': dict(
+        b_type=False,
+        reward_score=True,
+        reward_lines=False,
+        penalize_height=False,
+    ),
+    'TetrisA-v1': dict(
+        b_type=False,
+        reward_score=False,
+        reward_lines=True,
+        penalize_height=False,
+    ),
+    'TetrisA-v2': dict(
+        b_type=False,
+        reward_score=True,
+        reward_lines=False,
+        penalize_height=True,
+    ),
+    'TetrisA-v3': dict(
+        b_type=False,
+        reward_score=False,
+        reward_lines=True,
+        penalize_height=True,
+    ),
+    'TetrisB-v0': dict(
+        b_type=True,
+        reward_score=True,
+        reward_lines=False,
+        penalize_height=False,
+    ),
+    'TetrisB-v1': dict(
+        b_type=True,
+        reward_score=False,
+        reward_lines=True,
+        penalize_height=False,
+    ),
+    'TetrisB-v2': dict(
+        b_type=True,
+        reward_score=True,
+        reward_lines=False,
+        penalize_height=True,
+    ),
+    'TetrisB-v3': dict(
+        b_type=True,
+        reward_score=False,
+        reward_lines=True,
+        penalize_height=True,
+    ),
+}
+
+
 def unwrap(env):
-    """Return the base environment under Gym API compatibility wrappers."""
+    """Return the base environment under Gymnasium API wrappers."""
     return env.unwrapped
 
 
-class ShouldMakeTetrisAv0(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisA-v0'))
-        self.assertFalse(env._b_type)
-        self.assertTrue(env._reward_score)
-        self.assertFalse(env._reward_lines)
-        self.assertFalse(env._penalize_height)
+def make_env(env_id, **kwargs):
+    """Create an environment while accepting intentionally versioned IDs."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='.*The environment .* is out of date.*',
+            category=DeprecationWarning,
+        )
+        return gym.make(env_id, **kwargs)
 
 
-class ShouldMakeTetrisAv1(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisA-v1'))
-        self.assertFalse(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertFalse(env._penalize_height)
+class ShouldRegisterGymnasiumEnvironments(TestCase):
+    def assert_env_configuration(self, env_id, kwargs):
+        """Assert a registered environment preserves its constructor options."""
+        env = make_env(env_id, render_mode='rgb_array')
+        try:
+            base = unwrap(env)
+            self.assertEqual(kwargs['b_type'], base._b_type)
+            self.assertEqual(kwargs['reward_score'], base._reward_score)
+            self.assertEqual(kwargs['reward_lines'], base._reward_lines)
+            self.assertEqual(kwargs['penalize_height'], base._penalize_height)
+            self.assertEqual('rgb_array', base.render_mode)
+            self.assertEqual(256, env.action_space.n)
+        finally:
+            env.close()
+
+    def test_all_registered_ids_are_available_through_gymnasium(self):
+        for env_id, kwargs in REGISTERED_ENVIRONMENTS.items():
+            with self.subTest(env_id=env_id):
+                self.assert_env_configuration(env_id, kwargs)
+
+    def test_make_alias_uses_gymnasium_make(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message='.*The environment .* is out of date.*',
+                category=DeprecationWarning,
+            )
+            env = make('TetrisA-v0', render_mode='rgb_array')
+        try:
+            self.assertFalse(unwrap(env)._b_type)
+            self.assertTrue(unwrap(env)._reward_score)
+        finally:
+            env.close()
 
 
-class ShouldMakeTetrisAv2(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisA-v2'))
-        self.assertFalse(env._b_type)
-        self.assertTrue(env._reward_score)
-        self.assertFalse(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+class ShouldUseGymnasiumStepApiForATypeAndBType(TestCase):
+    def assert_reset_and_step_api(self, env_id):
+        """Assert the public reset and step tuple contracts."""
+        env = make_env(env_id, render_mode='rgb_array')
+        try:
+            reset_result = env.reset(seed=123)
+            self.assertIsInstance(reset_result, tuple)
+            self.assertEqual(2, len(reset_result))
+            observation, info = reset_result
+            self.assertEqual((240, 256, 3), observation.shape)
+            self.assertIsInstance(info, dict)
 
+            step_result = env.step(env.action_space.sample())
+            self.assertIsInstance(step_result, tuple)
+            self.assertEqual(5, len(step_result))
+            observation, reward, terminated, truncated, info = step_result
+            self.assertEqual((240, 256, 3), observation.shape)
+            self.assertIsInstance(reward, float)
+            self.assertIsInstance(terminated, bool)
+            self.assertIsInstance(truncated, bool)
+            self.assertIn('score', info)
+            self.assertIsNotNone(env.render())
+        finally:
+            env.close()
 
-class ShouldMakeTetrisAv3(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisA-v3'))
-        self.assertFalse(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+    def test_a_type_v0(self):
+        self.assert_reset_and_step_api('TetrisA-v0')
 
-
-class ShouldMakeTetrisBv0(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisB-v0'))
-        self.assertTrue(env._b_type)
-        self.assertTrue(env._reward_score)
-        self.assertFalse(env._reward_lines)
-        self.assertFalse(env._penalize_height)
-
-
-class ShouldMakeTetrisBv1(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisB-v1'))
-        self.assertTrue(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertFalse(env._penalize_height)
-
-
-class ShouldMakeTetrisBv2(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisB-v2'))
-        self.assertTrue(env._b_type)
-        self.assertTrue(env._reward_score)
-        self.assertFalse(env._reward_lines)
-        self.assertTrue(env._penalize_height)
-
-
-class ShouldMakeTetrisBv3(TestCase):
-    def test(self):
-        env = unwrap(make('TetrisB-v3'))
-        self.assertTrue(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+    def test_b_type_v0(self):
+        self.assert_reset_and_step_api('TetrisB-v0')

--- a/gym_tetris/tests/test_tetris_env.py
+++ b/gym_tetris/tests/test_tetris_env.py
@@ -1,97 +1,301 @@
-"""Test cases for the Super Mario Bros meta environment."""
+"""Test cases for the Tetris Gymnasium environment."""
 from unittest import TestCase
+
+import numpy as np
+
 from ..tetris_env import TetrisEnv
+
+
+EXPECTED_INFO_KEYS = {
+    'current_piece',
+    'number_of_lines',
+    'score',
+    'next_piece',
+    'statistics',
+    'board_height',
+}
+
+
+class RewardProbeTetrisEnv(TetrisEnv):
+    """Tetris environment with controllable reward inputs."""
+
+    def __init__(self, **kwargs):
+        """Initialize the probe with stable synthetic metrics."""
+        self._fake_score = 0
+        self._fake_lines = 0
+        self._fake_height = 0
+        kwargs.setdefault('deterministic', True)
+        super().__init__(**kwargs)
+
+    @property
+    def _score(self):
+        """Return the synthetic score."""
+        return self._fake_score
+
+    @property
+    def _number_of_lines(self):
+        """Return the synthetic number of cleared lines."""
+        return self._fake_lines
+
+    @property
+    def _board_height(self):
+        """Return the synthetic board height."""
+        return self._fake_height
+
+    def set_metrics(self, score, lines, height):
+        """Set the synthetic reward inputs."""
+        self._fake_score = score
+        self._fake_lines = lines
+        self._fake_height = height
+
+
+class TetrisEnvAssertions(TestCase):
+    """Shared assertions for the public Gymnasium API."""
+
+    def assert_valid_observation(self, observation):
+        """Assert that an observation matches the NES RGB frame contract."""
+        self.assertIsInstance(observation, np.ndarray)
+        self.assertEqual((240, 256, 3), observation.shape)
+        self.assertEqual(np.uint8, observation.dtype)
+
+    def assert_is_not_black_screen(self, screen):
+        """Assert that the given screen is not empty."""
+        self.assertNotEqual(0, screen.sum())
+
+    def assert_info_keys(self, info):
+        """Assert that the public Tetris info keys are stable."""
+        self.assertEqual(EXPECTED_INFO_KEYS, set(info.keys()))
+
+    def reset_env(self, env, seed=None):
+        """Reset an environment and assert the Gymnasium reset tuple."""
+        output = env.reset(seed=seed)
+        self.assertIsInstance(output, tuple)
+        self.assertEqual(2, len(output))
+        observation, info = output
+        self.assert_valid_observation(observation)
+        self.assertIsInstance(info, dict)
+        self.assert_info_keys(info)
+        return observation, info
+
+    def step_env(self, env, action):
+        """Step an environment and assert the Gymnasium step tuple."""
+        output = env.step(action)
+        self.assertIsInstance(output, tuple)
+        self.assertEqual(5, len(output))
+        observation, reward, terminated, truncated, info = output
+        self.assert_valid_observation(observation)
+        self.assertIsInstance(reward, float)
+        self.assertIsInstance(terminated, bool)
+        self.assertIsInstance(truncated, bool)
+        self.assertFalse(truncated)
+        self.assertIsInstance(info, dict)
+        self.assert_info_keys(info)
+        return observation, reward, terminated, truncated, info
 
 
 class ShouldCreateEnvWithDefaultRewardLines(TestCase):
     def test(self):
         env = TetrisEnv()
-        self.assertFalse(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertTrue(env._penalize_height)
-        self.assertEqual(0, env._current_score)
-        self.assertEqual(0, env._current_lines)
-        self.assertEqual(0, env._current_height)
+        try:
+            self.assertFalse(env._b_type)
+            self.assertFalse(env._reward_score)
+            self.assertTrue(env._reward_lines)
+            self.assertTrue(env._penalize_height)
+            self.assertIsNone(env.render_mode)
+            self.assertEqual(0, env._current_score)
+            self.assertEqual(0, env._current_lines)
+            self.assertEqual(0, env._current_height)
+        finally:
+            env.close()
 
 
 class ShouldCreateEnvWithRewardScore(TestCase):
     def test(self):
         env = TetrisEnv(reward_score=True)
-        self.assertFalse(env._b_type)
-        self.assertTrue(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+        try:
+            self.assertFalse(env._b_type)
+            self.assertTrue(env._reward_score)
+            self.assertTrue(env._reward_lines)
+            self.assertTrue(env._penalize_height)
+        finally:
+            env.close()
 
 
 class ShouldCreateEnvWithoutPenalizeHeight(TestCase):
     def test(self):
         env = TetrisEnv(penalize_height=False)
-        self.assertFalse(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertFalse(env._penalize_height)
+        try:
+            self.assertFalse(env._b_type)
+            self.assertFalse(env._reward_score)
+            self.assertTrue(env._reward_lines)
+            self.assertFalse(env._penalize_height)
+        finally:
+            env.close()
 
 
 class ShouldCreateEnvWithoutRewardLines(TestCase):
     def test(self):
         env = TetrisEnv(reward_lines=False)
-        self.assertFalse(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertFalse(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+        try:
+            self.assertFalse(env._b_type)
+            self.assertFalse(env._reward_score)
+            self.assertFalse(env._reward_lines)
+            self.assertTrue(env._penalize_height)
+        finally:
+            env.close()
 
 
 class ShouldCreateEnvWithBType(TestCase):
     def test(self):
         env = TetrisEnv(b_type=True)
-        self.assertTrue(env._b_type)
-        self.assertFalse(env._reward_score)
-        self.assertTrue(env._reward_lines)
-        self.assertTrue(env._penalize_height)
+        try:
+            self.assertTrue(env._b_type)
+            self.assertFalse(env._reward_score)
+            self.assertTrue(env._reward_lines)
+            self.assertTrue(env._penalize_height)
+        finally:
+            env.close()
 
 
-class ShouldStep(TestCase):
+class ShouldSupportRenderMode(TetrisEnvAssertions):
+    def test(self):
+        env = TetrisEnv(render_mode='rgb_array')
+        try:
+            observation, _ = self.reset_env(env, seed=1)
+            self.assertIs(env.render(), env.screen)
+            self.assert_valid_observation(env.render())
+            self.assertTrue(np.array_equal(observation, env.render()))
+        finally:
+            env.close()
+
+
+class ShouldStep(TetrisEnvAssertions):
+    def test(self):
+        env = TetrisEnv(deterministic=True)
+        try:
+            _ = self.reset_env(env, seed=1)
+            _, reward, terminated, truncated, info = self.step_env(env, 0)
+            self.assertEqual(0, reward)
+            self.assertFalse(terminated)
+            self.assertFalse(truncated)
+            self.assertEqual('Jd', info['current_piece'])
+            self.assertEqual(0, info['number_of_lines'])
+            self.assertEqual(0, info['score'])
+            self.assertEqual('Zh', info['next_piece'])
+            stats = {'T': 0, 'J': 1, 'Z': 0, 'O': 0, 'S': 0, 'L': 0, 'I': 0}
+            self.assertEqual(stats, info['statistics'])
+        finally:
+            env.close()
+
+
+class ShouldUseGymnasiumResetSeeding(TetrisEnvAssertions):
+    def snapshot(self, env, seed):
+        """Return a copied reset snapshot for deterministic comparisons."""
+        observation, info = self.reset_env(env, seed=seed)
+        return observation.copy(), info.copy()
+
+    def test_seeded_non_deterministic_mode_is_reproducible(self):
+        env = TetrisEnv()
+        try:
+            first_state, first_info = self.snapshot(env, seed=123)
+            self.step_env(env, 0)
+            second_state, second_info = self.snapshot(env, seed=123)
+            self.assertTrue(np.array_equal(first_state, second_state))
+            self.assertEqual(first_info, second_info)
+        finally:
+            env.close()
+
+    def test_deterministic_mode_ignores_seeded_rng_variation(self):
+        env = TetrisEnv(deterministic=True)
+        try:
+            first_state, first_info = self.snapshot(env, seed=123)
+            self.step_env(env, 0)
+            second_state, second_info = self.snapshot(env, seed=456)
+            self.assertTrue(np.array_equal(first_state, second_state))
+            self.assertEqual(first_info, second_info)
+        finally:
+            env.close()
+
+
+class ShouldCalculateRewardModes(TestCase):
+    def test(self):
+        cases = [
+            (
+                'score',
+                dict(
+                    reward_score=True,
+                    reward_lines=False,
+                    penalize_height=False,
+                ),
+                100,
+            ),
+            (
+                'lines',
+                dict(
+                    reward_score=False,
+                    reward_lines=True,
+                    penalize_height=False,
+                ),
+                2,
+            ),
+            (
+                'score_height',
+                dict(
+                    reward_score=True,
+                    reward_lines=False,
+                    penalize_height=True,
+                ),
+                97,
+            ),
+            (
+                'lines_height',
+                dict(
+                    reward_score=False,
+                    reward_lines=True,
+                    penalize_height=True,
+                ),
+                -1,
+            ),
+        ]
+        for name, kwargs, expected_reward in cases:
+            with self.subTest(name=name):
+                env = RewardProbeTetrisEnv(**kwargs)
+                try:
+                    env.set_metrics(score=100, lines=2, height=3)
+                    self.assertEqual(expected_reward, env._get_reward())
+                    self.assertEqual(100, env._current_score)
+                    self.assertEqual(2, env._current_lines)
+                    self.assertEqual(3, env._current_height)
+                finally:
+                    env.close()
+
+
+class ShouldTerminate(TetrisEnvAssertions):
+    def test_game_over_uses_gymnasium_terminated_hook(self):
+        env = TetrisEnv()
+        try:
+            self.reset_env(env, seed=1)
+            env.ram[0x0058] = 1
+            self.assertTrue(env._get_terminated())
+        finally:
+            env.close()
+
+
+class ShouldCompleteEpisode(TetrisEnvAssertions):
     def test(self):
         env = TetrisEnv()
-        env.seed(1)
-        _ = env.reset()
-        _, reward, _, info = env.step(0)
-        # check all the information
-        self.assertEqual(0, reward)
-        self.assertEqual('Ih', info['current_piece'])
-        self.assertEqual(0, info['number_of_lines'])
-        self.assertEqual(0, info['score'])
-        self.assertEqual('Sh', info['next_piece'])
-        stats = {'T': 0, 'J': 0, 'Z': 0, 'O': 0, 'S': 0, 'L': 0, 'I': 1}
-        self.assertEqual(stats, info['statistics'])
-
-        env.close()
-
-
-class ShouldCompleteEpisode(TestCase):
-
-    def assertIsNotBlackScreen(self, screen):
-        """
-        Assert that the given screen (as a NumPy vector) is not empty.
-
-        Args:
-            screen: the screen to validate
-
-        Returns:
-            None
-
-        """
-        self.assertNotEqual(0, screen.sum())
-
-    def test(self):
-        env = TetrisEnv()
-        s = env.reset()
-        self.assertIsNotBlackScreen(s)
-        done = False
-        while not done:
-            s, r, done, i = env.step(0)
-            self.assertIsNotBlackScreen(s)
-        s = env.reset()
-        self.assertIsNotBlackScreen(s)
-        env.close()
+        try:
+            state, _ = self.reset_env(env, seed=1)
+            self.assert_is_not_black_screen(state)
+            done = False
+            for _ in range(10000):
+                state, _, terminated, truncated, _ = self.step_env(env, 0)
+                self.assert_is_not_black_screen(state)
+                done = terminated or truncated
+                if done:
+                    break
+            self.assertTrue(done)
+            state, _ = self.reset_env(env, seed=1)
+            self.assert_is_not_black_screen(state)
+        finally:
+            env.close()

--- a/gym_tetris/tetris_env.py
+++ b/gym_tetris/tetris_env.py
@@ -1,4 +1,4 @@
-"""An OpenAI Gym environment for Tetris."""
+"""A Gymnasium environment for Tetris."""
 import os
 from nes_py import NESEnv
 
@@ -36,7 +36,7 @@ _PIECE_ORIENTATION_TABLE = [
 
 
 class TetrisEnv(NESEnv):
-    """An environment for playing Tetris with OpenAI Gym."""
+    """An environment for playing Tetris with Gymnasium."""
 
     # the legal range of rewards for each step
     reward_range = (-float('inf'), float('inf'))
@@ -47,6 +47,7 @@ class TetrisEnv(NESEnv):
         reward_lines: bool = True,
         penalize_height: bool = True,
         deterministic: bool = False,
+        render_mode=None,
     ) -> None:
         """
         Initialize a new Tetris environment.
@@ -57,12 +58,13 @@ class TetrisEnv(NESEnv):
             reward_lines: whether to reward using the number of lines cleared
             penalize_height: whether to penalize based on height of the board
             deterministic: true to disable RNG in the engine
+            render_mode: the Gymnasium render mode to use, if any
 
         Returns:
             None
 
         """
-        super().__init__(_ROM_PATH)
+        super().__init__(_ROM_PATH, render_mode=render_mode)
         self._b_type = b_type
         self._reward_score = reward_score
         self._current_score = 0
@@ -187,8 +189,10 @@ class TetrisEnv(NESEnv):
         # generate a random number for the Tetris RNG
         seed = 0, 0
         if not self.deterministic:
-            seed = self.np_random.randint(0, 255), self.np_random.randint(0, 255)
-        # seed = self.np_random.randint(0, 255), self.np_random.randint(0, 255)
+            seed = (
+                self.np_random.integers(0, 255),
+                self.np_random.integers(0, 255),
+            )
         # skip garbage screens
         while self.ram[0x00C0] in {0, 1, 2, 3}:
             # seed the random number generator
@@ -205,7 +209,10 @@ class TetrisEnv(NESEnv):
         # skip frames and seed the random number generator
         seed = 0, 0
         if not self.deterministic:
-            seed = self.np_random.randint(0, 255), self.np_random.randint(0, 255)
+            seed = (
+                self.np_random.integers(0, 255),
+                self.np_random.integers(0, 255),
+            )
         for _ in range(14):
             self.ram[0x0017:0x0019] = seed
             self._frame_advance(0)
@@ -236,7 +243,7 @@ class TetrisEnv(NESEnv):
 
         return reward
 
-    def _get_done(self):
+    def _get_terminated(self):
         """Return True if the episode is over, False otherwise."""
         return self._is_game_over or self._did_win_game
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gym_tetris"
-version = "3.0.4"
-description = "Tetris (NES) for OpenAI Gym"
+version = "4.0.0"
+description = "Tetris (NES) for Gymnasium"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 license = { text = "Proprietary" }
 authors = [
   { name = "Christian Kauten", email = "kautencreations@gmail.com" },
 ]
 keywords = [
-  "OpenAI-Gym",
+  "Gymnasium",
   "NES",
   "Tetris",
   "Reinforcement-Learning-Environment",
@@ -32,8 +32,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "gym>=0.25.2,<0.26",
-  "nes-py>=8.2.1",
+  "gymnasium>=1.0.0",
+  "nes-py>=9.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gym_tetris"
 version = "4.0.0"
 description = "Tetris (NES) for Gymnasium"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13"
 license = { text = "Proprietary" }
 authors = [
   { name = "Christian Kauten", email = "kautencreations@gmail.com" },
@@ -28,6 +28,7 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Games/Entertainment :: Side-Scrolling/Arcade Games",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Developer/CI bootstrap only. Canonical package metadata lives in pyproject.toml.
-gymnasium>=1.0.0
+# Developer/CI bootstrap only. Canonical runtime metadata lives in
+# pyproject.toml.
 nes-py @ git+https://github.com/Kautenja/nes-py.git@ralph-dev
 build>=1.2.1
 PyYAML>=6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Developer/CI bootstrap only. Canonical package metadata lives in pyproject.toml.
 gymnasium>=1.0.0
-nes-py @ git+https://github.com/Kautenja/nes-py.git@fa84702640d4bedfdbc66304a19fd5d8e5c835e3
+nes-py @ git+https://github.com/Kautenja/nes-py.git@ralph-dev
 build>=1.2.1
 PyYAML>=6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Developer/CI bootstrap only. Canonical package metadata lives in pyproject.toml.
-nes-py @ git+https://github.com/Kautenja/nes-py.git@989aa0268990b686fe0bd430e2a9f529f39e0f29
+gymnasium>=1.0.0
+nes-py @ git+https://github.com/Kautenja/nes-py.git@fa84702640d4bedfdbc66304a19fd5d8e5c835e3
 build>=1.2.1
 PyYAML>=6.0.2


### PR DESCRIPTION
Merge the Ralph development branch back into master for wrapper Python and CI dependency parity. This includes Python 3.14 support and classifiers, expanded CI matrix coverage, the shared ralph-dev nes-py bootstrap policy, and consistent requirements metadata comments.