### PR TITLE
[codex] Fix master-based nes-py CI bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           gh release view "$TAG_NAME" || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Automated release for $TAG_NAME"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Developer/CI bootstrap only. Canonical runtime metadata lives in
 # pyproject.toml.
-nes-py @ git+https://github.com/Kautenja/nes-py.git@ralph-dev
+nes-py @ git+https://github.com/Kautenja/nes-py.git@master
 build>=1.2.1
 PyYAML>=6.0.2


### PR DESCRIPTION
## Summary

Update CI bootstrap dependencies to install `nes-py` from the `master` branch instead of the removed `ralph-dev` branch, and keep the release artifact upload job passing explicit repository context to `gh`.

## Root Cause

Wrapper repo CI still installed `nes-py @ git+https://github.com/Kautenja/nes-py.git@ralph-dev` from `requirements.txt`. That branch no longer exists in `Kautenja/nes-py`, so release builds fail during dependency installation before tests or packaging run.

## Changes

- Switch `requirements.txt` bootstrap dependency from `nes-py@ralph-dev` to `nes-py@master`
- Set `GH_REPO: ${{ github.repository }}` in the release artifact upload step so `gh release` works without a local checkout

## Validation

- Re-scanned wrapper repos for live `nes-py@ralph-dev` references
- Ran `git diff --check` on the changed files
- Verified `git ls-remote` shows `master` and not `ralph-dev` in `Kautenja/nes-py`